### PR TITLE
fix(ci): Configure uv to use system Python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  UV_PYTHON_PREFERENCE: system
+
 jobs:
   # ============================================================================
   # Job 1: Lint - Code Style and Formatting
@@ -40,10 +43,10 @@ jobs:
         run: uv sync --all-extras
 
       - name: Run Ruff format check
-        run: uv run ruff format --check .
+        run: uv run --python 3.11 ruff format --check .
 
       - name: Run Ruff lint
-        run: uv run ruff check .
+        run: uv run --python 3.11 ruff check .
 
   # ============================================================================
   # Job 2: Type Check - Static Type Analysis
@@ -68,7 +71,7 @@ jobs:
         run: uv sync --all-extras
 
       - name: Run Pyright
-        run: PYTHONPATH=src uv run pyright
+        run: PYTHONPATH=src uv run --python 3.11 pyright
 
   # ============================================================================
   # Job 3: Test - Unit Tests Across Python Versions
@@ -94,10 +97,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: uv sync --all-extras
+        run: uv sync --all-extras --python ${{ matrix.python-version }}
 
       - name: Run tests with coverage
-        run: PYTHONPATH=src uv run pytest --cov --cov-report=xml --cov-report=term
+        run: PYTHONPATH=src uv run --python ${{ matrix.python-version }} pytest --cov --cov-report=xml --cov-report=term
 
       - name: Upload coverage to Codecov
         if: |
@@ -133,10 +136,10 @@ jobs:
         run: uv sync --all-extras
 
       - name: Run Bandit security scan
-        run: uv run bandit -r src/
+        run: uv run --python 3.11 bandit -r src/
 
       - name: Run pip-audit
-        run: uv run pip-audit
+        run: uv run --python 3.11 pip-audit
 
   # ============================================================================
   # Job 5: Build - Verify Package Build
@@ -167,7 +170,7 @@ jobs:
 
       - name: Verify package
         run: |
-          uv run twine check dist/*
+          uv run --python 3.11 twine check dist/*
           echo "Package built successfully"
           ls -lh dist/
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,9 @@ permissions:
   contents: write
   id-token: write
 
+env:
+  UV_PYTHON_PREFERENCE: system
+
 jobs:
   validate:
     name: Validate Release
@@ -66,18 +69,18 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: uv sync --all-extras
+        run: uv sync --all-extras --python ${{ matrix.python-version }}
 
       - name: Run linting
         run: |
-          uv run ruff format --check .
-          uv run ruff check .
+          uv run --python ${{ matrix.python-version }} ruff format --check .
+          uv run --python ${{ matrix.python-version }} ruff check .
 
       - name: Run type checking
-        run: PYTHONPATH=src uv run pyright
+        run: PYTHONPATH=src uv run --python ${{ matrix.python-version }} pyright
 
       - name: Run tests
-        run: PYTHONPATH=src uv run pytest
+        run: PYTHONPATH=src uv run --python ${{ matrix.python-version }} pytest
 
   build:
     name: Build Package
@@ -112,7 +115,7 @@ jobs:
 
       - name: Check package contents
         run: |
-          uv run twine check dist/*
+          uv run --python 3.11 twine check dist/*
           tar -tzf dist/*.tar.gz | head -20
 
       - name: Upload build artifacts


### PR DESCRIPTION
## Problem
CI workflows are failing with HTTP2 errors when uv tries to download Python builds from python-build-standalone releases:

```
error: Request failed after 3 retries
  Caused by: Failed to download https://github.com/astral-sh/python-build-standalone/releases/download/20251209/cpython-3.11.14%2B20251209-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz
  Caused by: http2 error
  Caused by: stream error received: refused stream before processing any application logic
```

## Root Cause
uv is attempting to download and manage its own Python versions instead of using the Python already installed by the `setup-python` action.

## Solution
Set `UV_PYTHON_PREFERENCE=system` environment variable at the workflow level to instruct uv to use the system Python.

## Changes
- ✅ Added `env: UV_PYTHON_PREFERENCE: system` to ci.yml
- ✅ Added `env: UV_PYTHON_PREFERENCE: system` to release.yml

## Testing
This PR will verify that the CI workflows now complete successfully without HTTP2 download errors.

Closes #5